### PR TITLE
Split resume scripts into router/theme/last-updated modules

### DIFF
--- a/resume/app.js
+++ b/resume/app.js
@@ -1,67 +1,18 @@
-// Tiny hash router for static GitHub Pages
 (function () {
-  // Route mapping: hash -> partial file
-  const routes = {
-    '#about': 'sections/about.html',
-    '#skills': 'sections/skills.html',
-    '#experience': 'sections/experience.html',
-    '#projects': 'sections/projects.html',
-    '#education': 'sections/education.html',
-    '#contact': 'sections/contact.html',
-    '#notes': 'sections/notes.html'
-  };
+  function init() {
+    const app = document.getElementById('app');
+    const lastUpdated = document.getElementById('lastUpdated');
 
-  const app = document.getElementById('app');
-  const lastUpdated = document.getElementById('lastUpdated');
-
-  // Theme toggle with persistence
-  (function theme() {
-    const stored = localStorage.getItem('theme');
-    const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
-    if (stored === 'light' || (!stored && prefersLight)) document.documentElement.classList.add('light');
-    const btn = document.getElementById('themeToggle');
-    btn && btn.addEventListener('click', () => {
-      document.documentElement.classList.toggle('light');
-      const isLight = document.documentElement.classList.contains('light');
-      localStorage.setItem('theme', isLight ? 'light' : 'dark');
-    });
-    // update "last updated"
-    try {
-      const dt = new Date(document.lastModified);
-      if (!Number.isNaN(+dt) && lastUpdated) {
-        lastUpdated.textContent = dt.toLocaleDateString('zh-TW', { year: 'numeric', month: '2-digit', day: '2-digit' });
-      }
-    } catch {}
-  })();
-
-  // Load and inject a partial file
-  async function load(path) {
-    try {
-      const res = await fetch(path, { cache: 'no-store' });
-      if (!res.ok) throw new Error(res.statusText);
-      const html = await res.text();
-      app.innerHTML = html;
-      highlightActive();
-      window.scrollTo({ top: 0, behavior: 'instant' });
-    } catch (err) {
-      app.innerHTML = `<p class="muted">載入失敗：${path}</p>`;
-      console.error(err);
+    if (typeof window.initTheme === 'function') {
+      window.initTheme();
+    }
+    if (typeof window.initLastUpdated === 'function') {
+      window.initLastUpdated(lastUpdated);
+    }
+    if (typeof window.initRouter === 'function') {
+      window.initRouter(app);
     }
   }
 
-  function highlightActive() {
-    const links = document.querySelectorAll('a[data-route]');
-    const h = location.hash || '#about';
-    links.forEach(a => a.classList.toggle('active', a.getAttribute('href') === h));
-  }
-
-  // Router entry
-  function router() {
-    const hash = location.hash || '#about';
-    const path = routes[hash] || routes['#about'];
-    load(path);
-  }
-
-  window.addEventListener('hashchange', router);
-  document.addEventListener('DOMContentLoaded', router);
+  document.addEventListener('DOMContentLoaded', init);
 })();

--- a/resume/index.html
+++ b/resume/index.html
@@ -81,6 +81,9 @@
     </footer>
   </div>
 
+  <script src="theme.js"></script>
+  <script src="last-updated.js"></script>
+  <script src="router.js"></script>
   <script src="app.js"></script>
   <script src="notes-carousel.js"></script>
 </body>

--- a/resume/last-updated.js
+++ b/resume/last-updated.js
@@ -1,0 +1,17 @@
+(function () {
+  function initLastUpdated(lastUpdated) {
+    if (!lastUpdated) return;
+    try {
+      const dt = new Date(document.lastModified);
+      if (!Number.isNaN(+dt)) {
+        lastUpdated.textContent = dt.toLocaleDateString('zh-TW', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit'
+        });
+      }
+    } catch {}
+  }
+
+  window.initLastUpdated = initLastUpdated;
+})();

--- a/resume/router.js
+++ b/resume/router.js
@@ -1,0 +1,46 @@
+// Tiny hash router for static GitHub Pages
+(function () {
+  const routes = {
+    '#about': 'sections/about.html',
+    '#skills': 'sections/skills.html',
+    '#experience': 'sections/experience.html',
+    '#projects': 'sections/projects.html',
+    '#education': 'sections/education.html',
+    '#contact': 'sections/contact.html',
+    '#notes': 'sections/notes.html'
+  };
+
+  async function load(app, path) {
+    try {
+      const res = await fetch(path, { cache: 'no-store' });
+      if (!res.ok) throw new Error(res.statusText);
+      const html = await res.text();
+      app.innerHTML = html;
+      highlightActive();
+      window.scrollTo({ top: 0, behavior: 'instant' });
+    } catch (err) {
+      app.innerHTML = `<p class="muted">載入失敗：${path}</p>`;
+      console.error(err);
+    }
+  }
+
+  function highlightActive() {
+    const links = document.querySelectorAll('a[data-route]');
+    const h = location.hash || '#about';
+    links.forEach(a => a.classList.toggle('active', a.getAttribute('href') === h));
+  }
+
+  function router(app) {
+    const hash = location.hash || '#about';
+    const path = routes[hash] || routes['#about'];
+    load(app, path);
+  }
+
+  function initRouter(app) {
+    if (!app) return;
+    window.addEventListener('hashchange', () => router(app));
+    router(app);
+  }
+
+  window.initRouter = initRouter;
+})();

--- a/resume/theme.js
+++ b/resume/theme.js
@@ -1,0 +1,19 @@
+// Theme toggle with persistence
+(function () {
+  function initTheme() {
+    const stored = localStorage.getItem('theme');
+    const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+    if (stored === 'light' || (!stored && prefersLight)) {
+      document.documentElement.classList.add('light');
+    }
+    const btn = document.getElementById('themeToggle');
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      document.documentElement.classList.toggle('light');
+      const isLight = document.documentElement.classList.contains('light');
+      localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    });
+  }
+
+  window.initTheme = initTheme;
+})();


### PR DESCRIPTION
### Motivation
- Reduce monolithic `app.js` by extracting routing, theme, and last-updated logic into separate modules for clarity and maintainability.
- Isolate responsibilities so each module (`router`, `theme`, `last-updated`) can be reasoned about and loaded independently.
- Keep a minimal bootstrap entry in `app.js` that wires modules together on `DOMContentLoaded`.

### Description
- Added `router.js` which contains the hash route map, `load()` to fetch partials, `highlightActive()`, and `initRouter()` which registers the `hashchange` handler and triggers initial routing.
- Added `theme.js` which provides `initTheme()` to apply persisted theme preference, wire the `#themeToggle` button, and persist changes to `localStorage`.
- Added `last-updated.js` which provides `initLastUpdated()` to populate the `#lastUpdated` footer element from `document.lastModified`.
- Simplified `app.js` to a small bootstrap that calls `window.initTheme()`, `window.initLastUpdated(lastUpdated)`, and `window.initRouter(app)` on `DOMContentLoaded`, and updated `index.html` to load `theme.js`, `last-updated.js`, and `router.js` before `app.js`.

### Testing
- No automated tests were run for these static site refactorings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e2d7fefcc832185632878fca7d05d)