### PR TITLE
Move tracking script to analytics.js and convert inline brand style to .brand-row

### DIFF
--- a/resume/analytics.js
+++ b/resume/analytics.js
@@ -1,0 +1,13 @@
+(function () {
+  const url = "https://shao.shaopara.workers.dev/track";
+  fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    keepalive: true,
+    body: JSON.stringify({
+      event: "page_view",
+      page: location.pathname,
+      ts: Date.now()
+    })
+  }).catch(() => {});
+})();

--- a/resume/index.html
+++ b/resume/index.html
@@ -26,28 +26,14 @@
   }
   </script>
 
-  <script>
-    (function () {
-      const url = "https://shao.shaopara.workers.dev/track";
-      fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        keepalive: true,
-        body: JSON.stringify({
-          event: "page_view",
-          page: location.pathname,
-          ts: Date.now()
-        })
-      }).catch(() => {});
-    })();
-  </script>
+  <script src="analytics.js"></script>
 </head>
 
 <body>
   <div class="layout">
     <!-- Top bar -->
     <header class="topbar card">
-      <div class="brand" style="display: flex; align-items: center; gap: 0.75rem;">
+      <div class="brand brand-row">
         <!-- 頭像在左 -->
         <img src="https://avatars.githubusercontent.com/u/24772930" alt="Hsiao 頭像" class="avatar">
         <div>

--- a/resume/styles.css
+++ b/resume/styles.css
@@ -29,6 +29,7 @@ a{color:var(--link); text-decoration:none}
 /* Layout */
 .layout{max-width:1080px; margin:0 auto; padding:20px}
 .topbar{display:grid; grid-template-columns:1fr auto auto; gap:16px; align-items:center; padding:16px 18px}
+.brand-row{display:flex; align-items:center; gap:.75rem}
 .brand .title{font-size:26px; font-weight:800; letter-spacing:.2px}
 .brand .subtitle{font-size:14px; color:var(--muted)}
 .menu{display:flex; gap:10px; flex-wrap:wrap}


### PR DESCRIPTION
### Motivation
- Separate concerns by extracting the inline page-view tracking snippet from `index.html` into a standalone `analytics.js` file for easier maintenance.
- Replace the inline `style` on the brand element with a reusable CSS class to keep markup clean and styles consolidated.

### Description
- Added `resume/analytics.js` which contains the page-view `fetch` tracking logic previously embedded in the HTML head.
- Replaced the inline tracking `<script>` block in `resume/index.html` with `<script src="analytics.js"></script>`.
- Introduced a `.brand-row` rule in `resume/styles.css` and updated the brand markup from `style="..."` to `class="brand brand-row"`.
- Staged and committed the updated `index.html`, `styles.css`, and the new `analytics.js` file.

### Testing
- Started a local static server with `python -m http.server` to serve the site, which ran successfully.
- Ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot to validate layout, which completed and produced an artifact.
- No automated unit tests were present or run for these static site changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e2f6492f0832191a0517e73aba16c)