### PR TITLE
Refactor notes carousel into parse, DOM and controller components

### DIFF
--- a/resume/index.html
+++ b/resume/index.html
@@ -71,6 +71,7 @@
   <script src="last-updated.js"></script>
   <script src="router.js"></script>
   <script src="app.js"></script>
+  <script src="parse.js"></script>
   <script src="notes-carousel.js"></script>
 </body>
 

--- a/resume/parse.js
+++ b/resume/parse.js
@@ -1,0 +1,42 @@
+/**
+ * parse.js
+ * - Parse <ul data-link-carousel> to groups for the carousel.
+ */
+(function () {
+  function normalizeTitle(s) {
+    return (s || "").replace(/\s+/g, " ").trim();
+  }
+
+  function parseGroupsFromUl(ul) {
+    const nodes = Array.from(ul.childNodes);
+
+    /** @type {{ title: string, items: HTMLLIElement[] }[]} */
+    const groups = [];
+    let current = null;
+
+    for (const n of nodes) {
+      if (n.nodeType === Node.COMMENT_NODE) {
+        const title = normalizeTitle(n.nodeValue);
+        if (!title) continue;
+        current = { title, items: [] };
+        groups.push(current);
+        continue;
+      }
+
+      if (n.nodeType === Node.ELEMENT_NODE && n.tagName === "LI") {
+        if (!current) {
+          current = { title: "Links", items: [] };
+          groups.push(current);
+        }
+        current.items.push(n);
+      }
+    }
+
+    // Remove empty groups (just in case)
+    return groups.filter((g) => g.items && g.items.length > 0);
+  }
+
+  window.notesCarouselParse = {
+    parseGroupsFromUl,
+  };
+})();


### PR DESCRIPTION
### Motivation
- Separate concerns so parsing, DOM creation and runtime control for the notes carousel are decoupled.  
- Make `parseGroupsFromUl` a reusable parser module for `<ul data-link-carousel>` data extraction.  
- Keep `initInRoot` / `startObserver` as the single startup/observer entry and compose smaller pieces at that layer.

### Description
- Extracted the parser into `resume/parse.js` and exposed it as `window.notesCarouselParse.parseGroupsFromUl`.  
- Split the old `buildCarousel` into `createCarouselDOM(groups)` which returns the DOM node and key element refs, `createCarouselState(groups, refs)` which holds rendering/timer logic, and `bindCarouselControls(refs, state)` which attaches events.  
- Updated `resume/notes-carousel.js` to consume the parser and compose `parse -> createCarouselDOM -> bindCarouselControls` inside `initInRoot`, and updated `resume/index.html` to load `parse.js` before `notes-carousel.js`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e3420d87483218880a17e8b6b0e57)