### PR TITLE
Refresh About & Experience layout, add highlight styles, Chinese README, and smooth scroll

### DIFF
--- a/resume/README.md
+++ b/resume/README.md
@@ -1,0 +1,25 @@
+# 履歷網站結構說明
+
+這份文件簡要說明各檔案的用途，方便後續維護與擴充。
+
+## 入口檔案
+- `index.html`：頁面骨架與導覽列，載入 CSS 與各個 JavaScript 模組。
+- `app.js`：初始化入口，負責啟動主題、最後更新日期與路由模組。
+
+## JavaScript 模組
+- `theme.js`：主題切換與偏好保存（localStorage）。
+- `last-updated.js`：讀取 `document.lastModified` 並更新頁尾日期。
+- `router.js`：Hash 路由與 section 載入，切換後回到頁面頂部。
+- `notes-carousel.js`：學習筆記輪播的組裝與互動控制。
+- `parse.js`：從 `ul[data-link-carousel]` 中解析分組資料，供輪播使用。
+- `analytics.js`：簡單的頁面瀏覽追蹤請求。
+
+## CSS 樣式
+- `base.css`：全域變數與基礎樣式（字體、背景、通用元素）。
+- `layout.css`：版面與區塊布局（topbar、footer、content）。
+- `components.css`：共用元件樣式（按鈕、badge、KV 區塊等）。
+- `notes-carousel.css`：學習筆記輪播的專屬樣式。
+
+## 其他資源
+- `favicon.ico`：網站小圖示。
+- `sections/`：各頁面區塊的 HTML 片段，供路由載入。

--- a/resume/components.css
+++ b/resume/components.css
@@ -29,3 +29,58 @@
 .link-group-actions { display:flex; gap:8px; }
 .link-group-list li.is-active a { font-weight:700; }
 .link-group-list li:not(.is-active) { opacity:.55; }
+
+.highlight{
+  padding:0 .3em;
+  border-radius:6px;
+  background:linear-gradient(120deg, rgba(120,180,255,.18), rgba(120,180,255,0));
+  font-weight:700;
+}
+
+.strengths{
+  list-style:none;
+  padding:0;
+  margin:0 0 1rem;
+}
+
+.strengths li{
+  padding:10px 12px;
+  border:1px solid var(--border);
+  border-radius:12px;
+  background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(0,0,0,.03));
+  margin:0 0 10px;
+}
+
+.experience{
+  display:grid;
+  gap:16px;
+}
+
+.experience-card{
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:16px 18px;
+  background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(0,0,0,.04));
+}
+
+.experience-head{
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:space-between;
+  gap:8px 16px;
+  align-items:baseline;
+}
+
+.experience-role{
+  margin:0;
+}
+
+.experience-meta{
+  margin:0;
+  color:var(--muted);
+  font-size:14px;
+}
+
+.experience-list{
+  margin:.5rem 0 0 1.2rem;
+}

--- a/resume/router.js
+++ b/resume/router.js
@@ -17,7 +17,7 @@
       const html = await res.text();
       app.innerHTML = html;
       highlightActive();
-      window.scrollTo({ top: 0, behavior: 'instant' });
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     } catch (err) {
       app.innerHTML = `<p class="muted">載入失敗：${path}</p>`;
       console.error(err);

--- a/resume/sections/about.html
+++ b/resume/sections/about.html
@@ -4,33 +4,36 @@
 
   <p>
     我曾任職於 Micron Technology 內部開發團隊，具備 <strong>5+ 年</strong> 製造資訊系統與資料整合實務經驗，
-    專注於將生產資料轉化為可用資訊，支援監控、報表與決策流程。
+    擅長把生產資料轉成可操作的資訊，讓監控、報表與決策流程更穩定、可追溯。
   </p>
 
-  <ul>
+  <p>
+    以下是我在履歷中最能帶來價值的重點能力，方便你快速抓住核心：
+  </p>
+
+  <ul class="strengths">
     <li>
-      <strong>數據分析 / 資料整合：</strong>
-      ETL 流程設計、跨系統資料串接、資料品質檢核與指標口徑一致化
+      <span class="highlight">資料整合與指標治理：</span>
+      設計 ETL 與跨系統串接，建立資料品質檢核與指標口徑一致化
     </li>
     <li>
-      <strong>資料庫與效能：</strong>
-      MS SQL 查詢與效能優化，支援報表與監控場景
+      <span class="highlight">資料庫效能與報表支援：</span>
+      MS SQL 查詢／效能調校，確保監控與報表的穩定輸出
     </li>
     <li>
-      <strong>系統開發：</strong>
-      前端 Angular；後端 C# / Python，能與跨部門協作交付可維運的解決方案
+      <span class="highlight">系統開發與跨部門協作：</span>
+      前端 Angular、後端 C# / Python，能與不同角色溝通並交付可維運方案
     </li>
     <li>
-      <strong>專案協作：</strong>
-      參與/推動多項跨部門專案（5+），重視文件化、流程化與自動化以降低知識斷層
+      <span class="highlight">專案落地與流程化：</span>
+      參與/推動 5+ 跨部門專案，重視文件化、流程化與自動化
     </li>
     <li>
-      <strong>跨文化能力：</strong>
+      <span class="highlight">跨文化溝通與適應：</span>
       完成日本短期日語研習課程，具備良好的溝通與適應能力
     </li>
   </ul>
 
-  <!-- Optional: Add a short one-liner summary for recruiters -->
   <p>
     我希望投入以資料整合與分析為核心的角色，協助團隊提升資訊可視性、系統穩定性與決策效率。
   </p>

--- a/resume/sections/experience.html
+++ b/resume/sections/experience.html
@@ -1,28 +1,42 @@
 <!-- Experience -->
-<h1>經歷</h1>
+<section class="experience">
+  <h1>經歷</h1>
 
-<h2>Micron · <span class="muted">IT Software Engineer</span></h2>
-<p class="muted">Taoyuan, Taiwan · 2024/04 – 2025/02 · 11 個月</p>
-<ul>
-  <li>與排程團隊合作強化產品／生產系統，將流程需求落地為可維護的系統邏輯；透過變更控管降低流程波動，並維持生產影響在可接受範圍。</li>
-  <li>重構內部網站與製造系統，統一指標口徑並導入資料檢核（Data Validation）機制，降低監控訊號不一致造成的生產風險。</li>
-  <li>於 IT 專案中落實 Agile、CI/CD 與單元測試，確保資料邏輯與監控／報表變更的正確性、可追溯性與穩定性。</li>
-</ul>
+  <article class="experience-card">
+    <div class="experience-head">
+      <h2 class="experience-role">Micron · <span class="muted">IT Software Engineer</span></h2>
+      <p class="experience-meta">Taoyuan, Taiwan · 2024/04 – 2025/02 · 11 個月</p>
+    </div>
+    <ul class="experience-list">
+      <li>與排程團隊合作強化產品／生產系統，將流程需求落地為可維護的系統邏輯；透過 <span class="highlight">變更控管</span> 降低流程波動，維持生產影響在可接受範圍。</li>
+      <li>重構內部網站與製造系統，統一指標口徑並導入 <span class="highlight">資料檢核（Data Validation）</span> 機制，降低監控訊號不一致造成的生產風險。</li>
+      <li>於 IT 專案中落實 <span class="highlight">Agile、CI/CD 與單元測試</span>，確保資料邏輯與監控／報表變更的正確性與可追溯性。</li>
+    </ul>
+  </article>
 
-<h2>Micron · <span class="muted">IE OI Engineer &amp; Reporting</span></h2>
-<p class="muted">Taichung, Taiwan · 2021/10 – 2024/04 · 2 年 6 個月</p>
-<ul>
-  <li>與跨部門團隊合作開發 Microsoft Teams 聊天機器人，提供即時異常通知；分析異常類型與責任單位／值班角色對應關係，提升通知精準度，協助晶圓廠生產週期縮短 <strong>1.3 天</strong>。</li>
-  <li>建置 Angular 儀表板整合天車車載系統與天車狀態，透過資料庫彙整／計算關鍵指標與即時數據，提供單一監控視圖（Single Pane of Glass, SPOG），每日節省至少 <strong>4 小時</strong>監控作業時間。</li>
-  <li>重構內部 Angular 網站以視覺化產品系列 Cycle Time 報表，並將作業流程整合為一體化網頁操作，降低人為疏失、提升使用體驗，為跨部門每週減少 <strong>13 小時</strong>人工作業。</li>
-  <li>與生產單位合作開發基於 Angular 的設備 Recipe 調控平台，整合排程與機台資料並進行趨勢／瓶頸／例外分析，協助建立可落地的選機策略，提升生產彈性與整體效能。</li>
-</ul>
+  <article class="experience-card">
+    <div class="experience-head">
+      <h2 class="experience-role">Micron · <span class="muted">IE OI Engineer &amp; Reporting</span></h2>
+      <p class="experience-meta">Taichung, Taiwan · 2021/10 – 2024/04 · 2 年 6 個月</p>
+    </div>
+    <ul class="experience-list">
+      <li>與跨部門團隊合作開發 Microsoft Teams 聊天機器人，建立即時異常通知機制，協助晶圓廠生產週期縮短 <span class="highlight">1.3 天</span>。</li>
+      <li>建置 Angular 儀表板整合天車系統與狀態，提供單一監控視圖（SPOG），每日節省至少 <span class="highlight">4 小時</span>監控作業。</li>
+      <li>重構內部 Angular 網站，整合作業流程並視覺化 Cycle Time 報表，為跨部門每週減少 <span class="highlight">13 小時</span>人工作業。</li>
+      <li>開發設備 Recipe 調控平台，整合排程與機台資料並進行趨勢／瓶頸分析，建立可落地的選機策略。</li>
+    </ul>
+  </article>
 
-<h2>Micron · <span class="muted">AMHS Engineer &amp; System</span></h2>
-<p class="muted">Taichung, Taiwan · 2019/08 – 2021/10 · 2 年 2 個月</p>
-<ul>
-  <li>負責 AMHS 硬體 KPI 管理，使用 Tableau 與 SSRS 建置視覺化儀表板與趨勢／告警報表，提升硬體稼動與維護狀態可視性，免除各項 KPI 報表的人工彙整。</li>
-  <li>開發 ASP.NET 網頁平台提供即時績效指標報表，將會議準備時間降低 <strong>90%</strong>，並設計倉儲／設備狀態告警通知機制。</li>
-  <li>設計清單式報表並導入 RPA 自動化作業，提升作業效率 <strong>30%</strong> 並降低人工操作風險。</li>
-  <li>分析歷史搬運／路徑數據以優化 FOUP 搬運邏輯，使平均搬運時間縮短 <strong>0.3 分鐘</strong>。</li>
-</ul>
+  <article class="experience-card">
+    <div class="experience-head">
+      <h2 class="experience-role">Micron · <span class="muted">AMHS Engineer &amp; System</span></h2>
+      <p class="experience-meta">Taichung, Taiwan · 2019/08 – 2021/10 · 2 年 2 個月</p>
+    </div>
+    <ul class="experience-list">
+      <li>負責 AMHS 硬體 KPI 管理，使用 Tableau 與 SSRS 建置儀表板與趨勢／告警報表，提升硬體稼動與維護狀態可視性。</li>
+      <li>開發 ASP.NET 平台提供即時績效指標報表，將會議準備時間降低 <span class="highlight">90%</span>，並設計倉儲／設備狀態告警通知。</li>
+      <li>導入 RPA 自動化清單式報表作業，提升效率 <span class="highlight">30%</span> 並降低人工操作風險。</li>
+      <li>分析歷史搬運／路徑數據以優化 FOUP 搬運邏輯，使平均搬運時間縮短 <span class="highlight">0.3 分鐘</span>。</li>
+    </ul>
+  </article>
+</section>


### PR DESCRIPTION
### Motivation
- Present the About section as a guided, scannable strengths list with emphasized key phrases to improve reader guidance.
- Show work history as block-style experience cards so impact metrics and important text stand out.
- Provide reusable highlight and card styles to keep presentation consistent across sections.
- Keep routing UX smooth on section changes and add a Chinese `README.md` for easier maintenance.

### Description
- Rewrote `resume/sections/about.html` to a strengths list using `class="strengths"` and inline `<span class="highlight">` markers for emphasized phrases.
- Restructured `resume/sections/experience.html` into card blocks using `<article class="experience-card">` with `experience-head`/`experience-list` and highlighted metrics via `span.highlight`.
- Added component styles in `resume/components.css` for `.highlight`, `.strengths`, `.experience`, `.experience-card`, `.experience-head`, `.experience-meta`, and `.experience-list`.
- Updated `resume/router.js` to call `window.scrollTo({ top: 0, behavior: 'smooth' })` after loading a section and added `resume/README.md` (Chinese) documenting project files.

### Testing
- Served the site with `python -m http.server` and rendered `index.html#about` and `index.html#experience` with Playwright, which succeeded and saved screenshots to `artifacts/resume-about.png` and `artifacts/resume-experience.png`.
- An initial Playwright run using a Node script failed due to a syntax mismatch but was retried successfully with a Python Playwright script.
- No automated unit tests were added for these static content and CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e2cc07c3c8321a8ede34809a02f0f)