### PR TITLE
Add bilingual (EN/ZH) toggle and i18n support for resume site

### DIFF
--- a/resume/assets/js/app.js
+++ b/resume/assets/js/app.js
@@ -9,6 +9,9 @@
     if (typeof window.initLastUpdated === 'function') {
       window.initLastUpdated(lastUpdated);
     }
+    if (typeof window.initI18n === 'function') {
+      window.initI18n();
+    }
     if (typeof window.initRouter === 'function') {
       window.initRouter(app);
     }

--- a/resume/assets/js/i18n.js
+++ b/resume/assets/js/i18n.js
@@ -1,0 +1,132 @@
+(function () {
+  const LANG_KEY = 'resume_lang';
+  const translations = {
+    zh: {
+      'title.role': '｜軟體工程師',
+      'title.subtitle': 'Python · Web Full-Stack 學習者',
+      'nav.about': '關於我',
+      'nav.skills': '技能',
+      'nav.experience': '工作經歷',
+      'nav.education': '學歷',
+      'nav.projects': '個人專案',
+      'nav.notes': '學習筆記',
+      'nav.contact': '聯絡',
+      'actions.theme': '🌓 主題',
+      'footer.updated': '最後更新：',
+      'footer.copyright': '© Hsiao · 靜態部署於 GitHub Pages',
+      'noscript': '請開啟 JavaScript 以瀏覽此頁面內容。'
+    },
+    en: {
+      'title.role': '｜Software Engineer',
+      'title.subtitle': 'Python · Web Full-Stack Learner',
+      'nav.about': 'About',
+      'nav.skills': 'Skills',
+      'nav.experience': 'Experience',
+      'nav.education': 'Education',
+      'nav.projects': 'Projects',
+      'nav.notes': 'Notes',
+      'nav.contact': 'Contact',
+      'actions.theme': '🌓 Theme',
+      'footer.updated': 'Last updated: ',
+      'footer.copyright': '© Hsiao · Deployed on GitHub Pages',
+      'noscript': 'Please enable JavaScript to view this page.'
+    }
+  };
+
+  const meta = {
+    zh: {
+      lang: 'zh-Hant-TW',
+      title: 'Hsiao Lin｜工程師 Resume',
+      description: 'Hsiao Lin（工程師）的個人履歷：技能、經歷、專案與聯絡方式。',
+      ogTitle: 'Hsiao Lin｜工程師 Resume',
+      ogDescription: '技能、經歷、專案與聯絡方式。',
+      jobTitle: '工程師'
+    },
+    en: {
+      lang: 'en',
+      title: 'Hsiao Lin | Software Engineer Resume',
+      description: "Hsiao Lin's resume: skills, experience, projects, and contact information.",
+      ogTitle: 'Hsiao Lin | Software Engineer Resume',
+      ogDescription: 'Skills, experience, projects, and contact information.',
+      jobTitle: 'Software Engineer'
+    }
+  };
+
+  function applyTranslations(lang) {
+    const dict = translations[lang] || translations.zh;
+    document.querySelectorAll('[data-i18n]').forEach((el) => {
+      const key = el.dataset.i18n;
+      if (dict[key]) {
+        el.textContent = dict[key];
+      }
+    });
+  }
+
+  function updateMeta(lang) {
+    const info = meta[lang] || meta.zh;
+    document.documentElement.lang = info.lang;
+    document.title = info.title;
+
+    const description = document.querySelector('meta[name="description"]');
+    if (description) {
+      description.setAttribute('content', info.description);
+    }
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    if (ogTitle) {
+      ogTitle.setAttribute('content', info.ogTitle);
+    }
+    const ogDescription = document.querySelector('meta[property="og:description"]');
+    if (ogDescription) {
+      ogDescription.setAttribute('content', info.ogDescription);
+    }
+
+    const jsonLd = document.querySelector('script[type="application/ld+json"]');
+    if (jsonLd) {
+      try {
+        const data = JSON.parse(jsonLd.textContent);
+        data.jobTitle = info.jobTitle;
+        jsonLd.textContent = JSON.stringify(data, null, 2);
+      } catch (error) {
+        console.warn('Failed to update JSON-LD', error);
+      }
+    }
+  }
+
+  function updateLangToggle(lang) {
+    const toggle = document.getElementById('langToggle');
+    if (!toggle) return;
+    const nextLang = lang === 'zh' ? 'en' : 'zh';
+    toggle.textContent = nextLang === 'en' ? 'EN' : '中文';
+    toggle.setAttribute('aria-label', nextLang === 'en' ? 'Switch to English' : '切換為中文');
+  }
+
+  function setLanguage(lang) {
+    const normalized = lang === 'en' ? 'en' : 'zh';
+    localStorage.setItem(LANG_KEY, normalized);
+    applyTranslations(normalized);
+    updateMeta(normalized);
+    updateLangToggle(normalized);
+    if (typeof window.reloadRoute === 'function') {
+      window.reloadRoute();
+    }
+  }
+
+  function initI18n() {
+    const stored = localStorage.getItem(LANG_KEY);
+    const initial = stored || 'zh';
+    const toggle = document.getElementById('langToggle');
+    if (toggle) {
+      toggle.addEventListener('click', () => {
+        const current = localStorage.getItem(LANG_KEY) || 'zh';
+        setLanguage(current === 'zh' ? 'en' : 'zh');
+      });
+    }
+    setLanguage(initial);
+  }
+
+  window.getLanguage = function () {
+    return localStorage.getItem(LANG_KEY) || 'zh';
+  };
+  window.setLanguage = setLanguage;
+  window.initI18n = initI18n;
+})();

--- a/resume/assets/js/router.js
+++ b/resume/assets/js/router.js
@@ -1,14 +1,21 @@
 // Tiny hash router for static GitHub Pages
 (function () {
   const routes = {
-    '#about': 'sections/about.html',
-    '#skills': 'sections/skills.html',
-    '#experience': 'sections/experience.html',
-    '#projects': 'sections/projects.html',
-    '#education': 'sections/education.html',
-    '#contact': 'sections/contact.html',
-    '#notes': 'sections/notes.html'
+    '#about': 'about',
+    '#skills': 'skills',
+    '#experience': 'experience',
+    '#projects': 'projects',
+    '#education': 'education',
+    '#contact': 'contact',
+    '#notes': 'notes'
   };
+
+  function getSectionPath(hash) {
+    const key = routes[hash] || routes['#about'];
+    const lang = typeof window.getLanguage === 'function' ? window.getLanguage() : 'zh';
+    const base = lang === 'en' ? 'sections/en' : 'sections';
+    return `${base}/${key}.html`;
+  }
 
   async function load(app, path) {
     try {
@@ -32,7 +39,7 @@
 
   function router(app) {
     const hash = location.hash || '#about';
-    const path = routes[hash] || routes['#about'];
+    const path = getSectionPath(hash);
     load(app, path);
   }
 
@@ -40,6 +47,7 @@
     if (!app) return;
     window.addEventListener('hashchange', () => router(app));
     router(app);
+    window.reloadRoute = () => router(app);
   }
 
   window.initRouter = initRouter;

--- a/resume/index.html
+++ b/resume/index.html
@@ -40,38 +40,40 @@
         <!-- 頭像在左 -->
         <img src="https://avatars.githubusercontent.com/u/24772930" alt="Hsiao 頭像" class="avatar">
         <div>
-          <div class="title">Hsiao <span class="muted">｜軟體工程師</span></div>
-          <div class="subtitle">Python · Web Full-Stack 學習者</div>
+          <div class="title">Hsiao <span class="muted" data-i18n="title.role">｜軟體工程師</span></div>
+          <div class="subtitle" data-i18n="title.subtitle">Python · Web Full-Stack 學習者</div>
         </div>
       </div>
       <nav class="menu">
-        <a href="#about" data-route>關於我</a>
-        <a href="#skills" data-route>技能</a>
-        <a href="#experience" data-route>工作經歷</a>
-        <a href="#education" data-route>學歷</a>
-        <a href="#projects" data-route>個人專案</a>
-        <a href="#notes" data-route>學習筆記</a>
-        <a href="#contact" data-route>聯絡</a>
+        <a href="#about" data-route data-i18n="nav.about">關於我</a>
+        <a href="#skills" data-route data-i18n="nav.skills">技能</a>
+        <a href="#experience" data-route data-i18n="nav.experience">工作經歷</a>
+        <a href="#education" data-route data-i18n="nav.education">學歷</a>
+        <a href="#projects" data-route data-i18n="nav.projects">個人專案</a>
+        <a href="#notes" data-route data-i18n="nav.notes">學習筆記</a>
+        <a href="#contact" data-route data-i18n="nav.contact">聯絡</a>
       </nav>
       <div class="actions">
-        <button id="themeToggle" class="btn" aria-label="Toggle theme">🌓 主題</button>
+        <button id="langToggle" class="btn" aria-label="Switch language">EN</button>
+        <button id="themeToggle" class="btn" aria-label="Toggle theme" data-i18n="actions.theme">🌓 主題</button>
       </div>
     </header>
 
     <!-- Main view: content gets injected here -->
     <main id="app" class="view card" aria-live="polite">
       <!-- app.js will inject sections/*.html here -->
-      <noscript>請開啟 JavaScript 以瀏覽此頁面內容。</noscript>
+      <noscript data-i18n="noscript">請開啟 JavaScript 以瀏覽此頁面內容。</noscript>
     </main>
 
     <footer class="foot">
-      <div>最後更新：<span id="lastUpdated">—</span></div>
-      <div class="muted">© Hsiao · 靜態部署於 GitHub Pages</div>
+      <div><span data-i18n="footer.updated">最後更新：</span><span id="lastUpdated">—</span></div>
+      <div class="muted" data-i18n="footer.copyright">© Hsiao · 靜態部署於 GitHub Pages</div>
     </footer>
   </div>
 
   <script src="assets/js/theme.js"></script>
   <script src="assets/js/last-updated.js"></script>
+  <script src="assets/js/i18n.js"></script>
   <script src="assets/js/router.js"></script>
   <script src="assets/js/app.js"></script>
   <script src="assets/js/parse.js"></script>

--- a/resume/sections/en/about.html
+++ b/resume/sections/en/about.html
@@ -1,0 +1,42 @@
+<!-- About -->
+<section id="about">
+  <h1>About</h1>
+
+  <p>
+    I previously worked on Micron Technology's internal development team and have <strong>5+ years</strong> of hands-on
+    experience in manufacturing information systems and data integration. I focus on turning production data into
+    actionable insights so monitoring, reporting, and decision workflows stay stable and traceable.
+  </p>
+
+  <p>
+    Below are the core strengths that bring the most value in my resume:
+  </p>
+
+  <ul class="strengths">
+    <li>
+      <span class="highlight">Data integration &amp; metric governance:</span>
+      Design ETL and cross-system integrations with data quality checks and consistent metric definitions.
+    </li>
+    <li>
+      <span class="highlight">Database performance &amp; reporting:</span>
+      MS SQL query tuning to keep monitoring and reporting outputs reliable.
+    </li>
+    <li>
+      <span class="highlight">System development &amp; cross-team collaboration:</span>
+      Frontend Angular and backend C# / Python, able to collaborate across roles and deliver maintainable solutions.
+    </li>
+    <li>
+      <span class="highlight">Project delivery &amp; process enablement:</span>
+      Contributed to 5+ cross-functional initiatives with a focus on documentation, process, and automation.
+    </li>
+    <li>
+      <span class="highlight">Cross-cultural communication:</span>
+      Completed a short-term Japanese language program with strong adaptability and communication skills.
+    </li>
+  </ul>
+
+  <p>
+    I hope to work in data integration and analytics-focused roles to improve information visibility, system stability,
+    and decision efficiency for teams.
+  </p>
+</section>

--- a/resume/sections/en/contact.html
+++ b/resume/sections/en/contact.html
@@ -1,0 +1,8 @@
+<!-- Contact -->
+<h1>Contact</h1>
+<p class="muted">Feel free to email me or reach out via LinkedIn / GitHub.</p>
+<ul>
+  <li><strong>Email:</strong> <a href="mailto:bettylin0920@gmail.com">bettylin0920@gmail.com</a></li>
+  <li><strong>GitHub:</strong> <a href="https://github.com/kashao">@kashao</a></li>
+  <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/hsiao-lin-lin-0738b6173/">Hsiao Lin Lin</a></li>
+</ul>

--- a/resume/sections/en/education.html
+++ b/resume/sections/en/education.html
@@ -1,0 +1,25 @@
+<!-- Education -->
+<h1>Education</h1>
+<div class="edu">
+  <div class="edu-item">
+    <div>
+      <h3>Kyoto Minsai Japanese Language School</h3>
+      <div class="sub muted">Short-term Japanese program</div>
+    </div>
+    <div class="muted">Kyoto, Japan · 2025/04 – 2025/06</div>
+  </div>
+  <div class="edu-item">
+    <div>
+      <h3>NTHU (National Tsing Hua University)</h3>
+      <div class="sub muted">M.S. in Industrial Engineering and Engineering Management</div>
+    </div>
+    <div class="muted">Hsinchu, Taiwan · 2017/09 – 2019/07</div>
+  </div>
+  <div class="edu-item">
+    <div>
+      <h3>NCTU (National Chiao Tung University)</h3>
+      <div class="sub muted">B.S. in Industrial Engineering and Management</div>
+    </div>
+    <div class="muted">Hsinchu, Taiwan · 2013/09 – 2017/06</div>
+  </div>
+</div>

--- a/resume/sections/en/experience.html
+++ b/resume/sections/en/experience.html
@@ -1,0 +1,42 @@
+<!-- Experience -->
+<section class="experience">
+  <h1>Experience</h1>
+
+  <article class="experience-card">
+    <div class="experience-head">
+      <h2 class="experience-role">Micron · <span class="muted">IT Software Engineer</span></h2>
+      <p class="experience-meta">Taoyuan, Taiwan · 2024/04 – 2025/02 · 11 months</p>
+    </div>
+    <ul class="experience-list">
+      <li>Partnered with the scheduling team to strengthen product/manufacturing systems, translating process needs into maintainable logic; reduced process volatility via <span class="highlight">change control</span> and kept production impact within acceptable ranges.</li>
+      <li>Refactored internal websites and manufacturing systems, unified metric definitions, and introduced <span class="highlight">data validation</span> to reduce production risk from inconsistent monitoring signals.</li>
+      <li>Applied <span class="highlight">Agile, CI/CD, and unit testing</span> in IT projects to ensure data logic and monitoring/reporting changes were accurate and traceable.</li>
+    </ul>
+  </article>
+
+  <article class="experience-card">
+    <div class="experience-head">
+      <h2 class="experience-role">Micron · <span class="muted">IE OI Engineer &amp; Reporting</span></h2>
+      <p class="experience-meta">Taichung, Taiwan · 2021/10 – 2024/04 · 2 years 6 months</p>
+    </div>
+    <ul class="experience-list">
+      <li>Built a Microsoft Teams chatbot with cross-functional teams to deliver real-time abnormal notifications, shortening fab production cycles by <span class="highlight">1.3 days</span>.</li>
+      <li>Implemented an Angular dashboard integrating overhead transport systems for a single-pane-of-glass (SPOG) view, saving at least <span class="highlight">4 hours</span> of monitoring time daily.</li>
+      <li>Rebuilt an internal Angular site to consolidate workflows and visualize cycle time reports, reducing <span class="highlight">13 hours</span> of manual work per week across teams.</li>
+      <li>Developed a recipe tuning platform integrating scheduling and tool data, enabling trend/bottleneck analysis and practical tool selection strategies.</li>
+    </ul>
+  </article>
+
+  <article class="experience-card">
+    <div class="experience-head">
+      <h2 class="experience-role">Micron · <span class="muted">AMHS Engineer &amp; System</span></h2>
+      <p class="experience-meta">Taichung, Taiwan · 2019/08 – 2021/10 · 2 years 2 months</p>
+    </div>
+    <ul class="experience-list">
+      <li>Owned AMHS hardware KPI management and built Tableau/SSRS dashboards and trend/alert reports to improve visibility into utilization and maintenance status.</li>
+      <li>Built an ASP.NET platform for real-time performance reports, cutting meeting prep time by <span class="highlight">90%</span>, and designed warehouse/equipment alert notifications.</li>
+      <li>Introduced RPA automation for checklist-style reporting, improving efficiency by <span class="highlight">30%</span> and reducing manual risk.</li>
+      <li>Analyzed historical transport/route data to optimize FOUP logic, reducing average transport time by <span class="highlight">0.3 minutes</span>.</li>
+    </ul>
+  </article>
+</section>

--- a/resume/sections/en/notes.html
+++ b/resume/sections/en/notes.html
@@ -1,0 +1,82 @@
+<!-- Notes / Writing -->
+<h1>Notes / Writing</h1>
+
+<section class="project">
+  <h2><a href="https://shao.shaopara.workers.dev/h/_eGhc-AfQ16Z4rHwV4qkuA?src=github_site" target="_blank" rel="noopener">Learning Notes (HackMD)</a></h2>
+  <p class="muted">
+    Continuously updated technical notes focused on production-ready implementations and performance/operations in enterprise environments, covering IIS, Git, Angular, MSSQL, Python, C#, Colab, APIs, and workflows.
+  </p>
+
+  <div class="kv" style="margin-top:8px">
+    <div class="dt">Highlights</div>
+    <div class="dd">
+      <ul data-link-carousel>
+        <!-- Labs (hands-on) -->
+        <li><a href="https://shao.shaopara.workers.dev/h/A33W-24gSXOTLAvge0CUiw?src=github_site" target="_blank" rel="noopener">[Labs] Relay 隱藏 n8n Webhook 並轉發 Discord</a> <small class="muted">(created: 2026-01-07)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/Um-BFxDZT4iMyaH07eZgHA?src=github_site" target="_blank" rel="noopener">[Labs] 用 Pandoc + Python 將 DOCX 轉 EPUB：實作筆記</a> <small class="muted">(created: 2025-08-16)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/6I_Xup-BQkSYHC13zBikRg?src=github_site" target="_blank" rel="noopener">[Labs] GPU 加速字幕處理：Colab T4 + Whisper 實作紀錄</a> <small class="muted">(created: 2025-08-06)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/nUsT0PwNRfu9jjXkYISsyg?src=github_site" target="_blank" rel="noopener">[Labs] 本機多人語音轉寫：WhisperX + Hugging Face 實作筆記</a> <small class="muted">(created: 2025-08-05)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/7GU7BrnrR1S4y2Ao1yKclA?src=github_site" target="_blank" rel="noopener">[Labs] Twitch 開播通知機器人（二）：支援多伺服器/多頻道設定（SQLite）</a> <small class="muted">(created: 2023-07-25)</small></li>
+
+        <!-- Automation & Agents -->
+        <li><a href="https://shao.shaopara.workers.dev/h/lOsYeAseSoqOv0wxdaSqWQ?src=github_site" target="_blank" rel="noopener">[AI Agent] n8n 自動化記帳（一）：Gmail 刷卡通知 → Google Sheets</a> <small class="muted">(created: 2025-12-29)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/C_lS0GPDS4mEbawYmqvSFA?src=github_site" target="_blank" rel="noopener">[AI Agent] n8n 自動化記帳（二）：Drive 月結帳單解析（CSV/PDF）與合併通知</a> <small class="muted">(created: 2025-12-30)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/c1DRzUN7QwuykwqkJAvfEQ?src=github_site" target="_blank" rel="noopener">[AI Agent] Infra Track：Discord Interaction Endpoint（n8n 驗簽/解析）與 Zeabur 部署</a> <small class="muted">(created: 2026-01-02)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/dm81lUJtTYmdMhIE2k2HBg?src=github_site" target="_blank" rel="noopener">[AI Agent] n8n 自動化記帳（三）：Discord 流水 → AI Agent → Google Sheets</a> <small class="muted">(created: 2026-01-06)</small></li>
+
+        <!-- Foundations -->
+        <li><a href="https://shao.shaopara.workers.dev/h/tDKwN5i9TSGO3rnSCxyoGw?src=github_site" target="_blank" rel="noopener">[Programming Concepts] Pass by Value &amp; Reference in C#/TS/Python</a> <small class="muted">(created: 2025-01-26)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/m3swDfsXR02nOWGuFODuEw?src=github_site" target="_blank" rel="noopener">[Git] Undoing a Merge with Git Reset</a> <small class="muted">(created: 2025-01-28)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/olNnv2VURViNKMwO-ZCRTg?src=github_site" target="_blank" rel="noopener">[Git] Simplifying Commit History: Use Reset and Rebase</a> <small class="muted">(created: 2025-01-28)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/e9MfbtvRT0K_ygV-W4ZaxQ?src=github_site" target="_blank" rel="noopener">[DevOps] Reverse Proxy / Relay 用 Cloudflare Worker 把實際網址藏在後面</a> <small class="muted">(created: 2026-01-06)</small></li>
+
+        <!-- Frontend -->
+        <li><a href="https://shao.shaopara.workers.dev/h/fRvZaSfCQF-mpsTaUpuY6Q?src=github_site" target="_blank" rel="noopener">[Angular] AG Grid 實戰筆記：動態欄位、列操作按鈕、日期顯示與樣式</a> <small class="muted">(created: 2023-08-12)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/GcgBU-8KTP6CzZ9811z5-w?src=github_site" target="_blank" rel="noopener">[Angular] Building a Kanban Board with DragDropModule</a> <small class="muted">(created: 2024-03-17)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/1QQAckUFRM2iP43uuYpvPQ?src=github_site" target="_blank" rel="noopener">[Angular] ngx-bootstrap Modal：ModalService / initialState / 訂閱流程</a> <small class="muted">(created: 2023-08-13)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/pCF6HjSoQV6pH1mCd1lLIA?src=github_site" target="_blank" rel="noopener">[Angular] Integrating a Modal Component in Angular with ngx-bootstrap</a> <small class="muted">(created: 2024-03-12)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/hvMQ5q5KSXKdbT9hkb4bcA?src=github_site" target="_blank" rel="noopener">[JavaScript] 網頁即時顯示時間：Date + setInterval</a> <small class="muted">(created: 2022-04-19)</small></li>
+
+        <!-- Backend -->
+        <li><a href="https://shao.shaopara.workers.dev/h/-28h67PLQBCGZLsPSwj3Ig?src=github_site" target="_blank" rel="noopener">[API] Parallel Run with Python FastAPI</a> <small class="muted">(created: 2025-01-27)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/aM2uFs-OTHeepMBc0YwoYA?src=github_site" target="_blank" rel="noopener">[API] Multi-Thread with Python FastAPI</a> <small class="muted">(created: 2025-01-28)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/jXZqeHTES1auguaEo1-0WQ?src=github_site" target="_blank" rel="noopener">[API] Multiprocessing with Python FastAPI</a> <small class="muted">(created: 2025-01-28)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/Yrp8xbBBQzaJfvRIL7Wj4A?src=github_site" target="_blank" rel="noopener">[API] Streaming with Python FastAPI</a> <small class="muted">(created: 2025-01-28)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/TL8v9kkpQsuoYrBz92F6jw?src=github_site" target="_blank" rel="noopener">[IIS] 在 IIS 上使用 Python 的配置與運行指南</a> <small class="muted">(created: 2025-02-26)</small></li>
+
+        <!-- Data & Database -->
+        <li><a href="https://shao.shaopara.workers.dev/h/BsV1gzQbQW6lJEy6NhBAeg?src=github_site" target="_blank" rel="noopener">[MSSQL] Query Plan Overview</a> <small class="muted">(created: 2025-01-03)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/3jOETlOHT3mCJDRtAPVLuQ?src=github_site" target="_blank" rel="noopener">[MSSQL] Index Overview</a> <small class="muted">(created: 2025-01-27)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/hUWKCstlTyi3IopjfmgppA?src=github_site" target="_blank" rel="noopener">[MSSQL] Deadlock Overview</a> <small class="muted">(created: 2025-01-26)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/vSNpOne9SuaLS4rXcGBUfw?src=github_site" target="_blank" rel="noopener">[MSSQL] Understanding and Using SQL Functions</a> <small class="muted">(created: 2025-01-28)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/j6_-dk94TOKftABEvF0L2w?src=github_site" target="_blank" rel="noopener">[MSSQL] Roles Permission Management</a> <small class="muted">(created: 2025-03-20)</small></li>
+
+        <!-- Programming -->
+        <li><a href="https://shao.shaopara.workers.dev/h/EdYYCPVOReGM1dQzJ5bppQ?src=github_site" target="_blank" rel="noopener">[Python] FuzzyWuzzy 字串模糊比對（Levenshtein）</a> <small class="muted">(created: 2023-08-14)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/m75f--q3QwqscCIJP4E6WA?src=github_site" target="_blank" rel="noopener">[C#] Dependency Injection Guide</a> <small class="muted">(created: 2025-01-26)</small></li>
+        <li><a href="https://shao.shaopara.workers.dev/h/GeaafPjaRFKOV7fxJ7lyHg?src=github_site" target="_blank" rel="noopener">[C#] Using Entity Framework to Connect and Query MSSQL</a> <small class="muted">(created: 2025-01-27)</small></li>
+
+      </ul>
+
+    </div>
+
+    <div class="dt">Topics</div>
+    <div class="dd">
+      <span class="badge">Python</span>
+      <span class="badge">FastAPI</span>
+      <span class="badge">Django</span>
+      <span class="badge">Flask</span>
+
+      <span class="badge">MSSQL</span>
+      <span class="badge">Performance</span>
+
+      <span class="badge">Angular</span>
+      <span class="badge">C#</span>
+      <span class="badge">Git</span>
+
+      <span class="badge">DevOps</span>
+      <span class="badge">IIS</span>
+      <span class="badge">n8n</span>
+    </div>
+  </div>
+</section>

--- a/resume/sections/en/projects.html
+++ b/resume/sections/en/projects.html
@@ -1,0 +1,48 @@
+<!-- Projects -->
+<h1>Projects</h1>
+
+<section class="project">
+  <h2><a href="https://github.com/kashao/VenvManager" target="_blank" rel="noopener">VenvManager</a></h2>
+  <p class="muted">
+    A Windows virtual environment manager built with Python + Tkinter: create/delete venvs, install packages (single or from files), list packages and Python versions, and run activate.bat.
+  </p>
+  <div class="kv">
+    <div class="dt">Tech</div><div class="dd">Python 3, Tkinter</div>
+    <div class="dt">Highlights</div><div class="dd">GUI workflow, requirements support, packaging attempts</div>
+  </div>
+</section>
+
+<section class="project">
+  <h2><a href="https://github.com/kashao/DiscordStreamerAlert" target="_blank" rel="noopener">DiscordStreamerAlert</a></h2>
+  <p class="muted">
+    Discord bot integrating the Twitch API: notify channels when streamers go live; supports custom commands (stored in SQLite).
+  </p>
+  <div class="kv">
+    <div class="dt">Tech</div><div class="dd">Python 3.11+, Discord/Twitch API, SQLite</div>
+    <div class="dt">Features</div><div class="dd">!addstreamer, !removestreamer, !liststreamers, !addcommand, !removecommand</div>
+    <div class="dt">Config</div><div class="dd">config.yml (client_id/secret, token_url, etc.)</div>
+  </div>
+</section>
+
+<section class="project">
+  <h2><a href="https://github.com/kashao/Google-Route-Planner-on-Flask" target="_blank" rel="noopener">Google Route Planner on Flask</a></h2>
+  <p class="muted">
+    A Flask wrapper around Google Maps route planning: enter multiple origin/destination pairs and return distance/time with map results.
+  </p>
+  <div class="kv">
+    <div class="dt">Tech</div><div class="dd">Flask, Google Maps API, PyYAML</div>
+    <div class="dt">Setup</div><div class="dd">`pip install -r requirements.txt`, `python app.py` → http://localhost:5000/</div>
+    <div class="dt">Config</div><div class="dd">Config.yml requires a Google Maps API key</div>
+  </div>
+</section>
+
+<section class="project">
+  <h2><a href="https://github.com/kashao/simple-chat-application" target="_blank" rel="noopener">Simple Chat Application</a></h2>
+  <p class="muted">
+    Bootstrap 5 chat UI example: a quick starting point for message interfaces, with screenshots and component references.
+  </p>
+  <div class="kv">
+    <div class="dt">Tech</div><div class="dd">Bootstrap 5, frontend only</div>
+    <div class="dt">Highlights</div><div class="dd">Lightweight, easy to embed, ready-to-use chat layout</div>
+  </div>
+</section>

--- a/resume/sections/en/skills.html
+++ b/resume/sections/en/skills.html
@@ -1,0 +1,23 @@
+<!-- Skills -->
+<h1>Skills</h1>
+<div class="kv">
+  <div class="dt">Programming Languages</div>
+  <div class="dd">Python, C#, TypeScript</div>
+
+  <div class="dt">Web Development</div>
+  <div class="dd">Angular, HTML, CSS, Bootstrap, FastAPI, Django, Flask</div>
+
+  <div class="dt">Databases</div>
+  <div class="dd">MSSQL, MySQL, Oracle</div>
+
+  <div class="dt">Tools &amp; Platforms</div>
+  <div class="dd">Git, Visual Studio Code, Azure DevOps, Postman</div>
+
+  <div class="dt">Concepts &amp; Practices</div>
+  <div class="dd">CI/CD, Agile, Unit testing, RESTful API</div>
+</div>
+<div style="margin-top:10px">
+  <span class="badge">Native | Chinese</span>
+  <span class="badge">Proficient | English (TOEIC 680)</span>
+  <span class="badge">Beginner | Japanese (N4)</span>
+</div>


### PR DESCRIPTION
### Motivation

- Provide a simple bilingual experience so the resume site can be viewed in Chinese or English with localized UI labels and section content.
- Keep metadata and structured data (JSON-LD) consistent with the selected language for better accessibility and sharing.

### Description

- Add `assets/js/i18n.js` to manage language state (`localStorage` key `resume_lang`), translations for shared UI labels, metadata updates, and a language toggle behavior that reloads sections.
- Add a language toggle button `#langToggle` and annotate common UI strings in `index.html` with `data-i18n` attributes to enable runtime translation and metadata updates (title, description, OpenGraph, JSON-LD jobTitle).
- Update `assets/js/app.js` to initialize i18n before the router and update `assets/js/router.js` to load localized section files from `sections/en/*.html` when English is selected.
- Add English-localized content files under `sections/en/` for About, Skills, Experience, Projects, Education, Notes, and Contact.

### Testing

- Served the site locally with `python -m http.server 8000` to validate static serving of new assets and localized sections, which started successfully.
- Ran Playwright checks against `http://127.0.0.1:8000/index.html`; initial scripted clicks to toggle the button timed out, but a subsequent script that set `localStorage.setItem('resume_lang', 'en')` and reloaded the page completed successfully.
- The successful Playwright run produced a screenshot artifact at `artifacts/resume-en.png`, confirming English UI labels and English section content loaded correctly.
